### PR TITLE
fix: decode URL path before deleting static file

### DIFF
--- a/src/main/http.js
+++ b/src/main/http.js
@@ -119,7 +119,7 @@ export class HttpMonitor {
 							return
 						}
 
-						const fullPath = path.join(p.path, req.url)
+						const fullPath = path.join(p.path, req.path)
 						log.info('Deleting file: ' + fullPath)
 
 						fs.unlink(fullPath, (err) => {


### PR DESCRIPTION
## Summary

`req.url` contains the raw URL-encoded request path (e.g. `%20` for spaces), while `req.path` is decoded by Express to the actual path string.

The DELETE handler was using `req.url` to construct the file path passed to `fs.unlink`. For filenames containing spaces or other URL-encodable characters, `fs.unlink` would fail with `ENOENT` (file not found) because the encoded path doesn't match the actual filename on disk.

## Fix

Change `req.url` → `req.path` in the DELETE handler inside the `allowDelete` branch.

```diff
- const fullPath = path.join(p.path, req.url)
+ const fullPath = path.join(p.path, req.path)
```

## Reproduction

With a static path configured with `allowDelete: true`, attempt to DELETE a file whose name contains a space:

```bash
curl -X DELETE http://localhost:8005/vmix/my%20recording.mp4
# Before fix: 404 Not Found (ENOENT — %20 doesn't match space on disk)
# After fix:  200 OK
```

## Notes

This bug has existed since the `allowDelete` feature was introduced in commit `f4caf949` (2018-11-05).